### PR TITLE
fix: correct reference to process.env in ESLint configuration

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -80,7 +80,7 @@ export default typescriptEslint.config([
     name: 'custom/javascript/rules',
     rules: {
       'no-console': [
-        globalThis.process.env.NODE_ENV === 'development' ? 'warn' : 'error',
+        process.env.NODE_ENV === 'development' ? 'warn' : 'error',
         { allow: ['warn', 'error'] },
       ],
       'no-param-reassign': [


### PR DESCRIPTION
Signed-off-by: donniean <donniean1@gmail.com>